### PR TITLE
upload files within folders to single item

### DIFF
--- a/example_notebook/BioportalSearching.ipynb
+++ b/example_notebook/BioportalSearching.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -21,16 +21,16 @@
    "outputs": [],
    "source": [
     "# Specify the API URL of your Girder instance\n",
-    "girder_api_url = 'http://192.168.99.100:8080/api/v1/'\n",
+    "girder_api_url = 'http://localhost:8080/api/v1/'\n",
     "\n",
     "# Specify the path to the file or folder you wish to upload\n",
-    "local_path = '/Users/stuartnelson/Downloads/DICOMSlices'\n",
+    "local_path = '/Users/user/Downloads/sampleDICOM/sample1'\n",
     "\n",
     "# Specify the unix style path to where you want the file\n",
     "# on girder. Unix path starting with either \"/user/[user name]\", \n",
     "# for a user's resources or \"/collection/[collection name]\",\n",
     "# for resources under a collection.\n",
-    "girder_dest_path = 'collection/c'\n",
+    "girder_dest_path = 'collection/collection/folder'\n",
     "\n",
     "# Provide girder username and password\n",
     "username = 'test'\n",
@@ -61,10 +61,10 @@
    "source": [
     "from girder_uploader.metadataPresets import MetadataPresets\n",
     "# Specify the API URL of your Girder instance\n",
-    "girder_api_url = 'http://192.168.99.100:8080/api/v1/'\n",
+    "girder_api_url = 'http://localhost:8080/api/v1/'\n",
     "\n",
     "# Specify the path to the file or folder you wish to upload\n",
-    "local_path = '/Users/stuartnelson/Downloads/DICOMSlices'\n",
+    "local_path = '/Users/user/Downloads/sampleDICOM/sample1'\n",
     "\n",
     "# Specify the unix style path to where you want the file\n",
     "# on girder. Unix path starting with either \"/user/[user name]\", \n",
@@ -111,14 +111,28 @@
   },
   "widgets": {
    "state": {
-    "285e0de625a74c2eba3ebaf7893e62f8": {
+    "23914b1fd6a44d94a9ea6706de8c607f": {
      "views": [
       {
        "cell_index": 1
       }
      ]
     },
-    "ed4cb0b81393482693e057818c15e5eb": {
+    "4c19eb25874946538712201772efb4f2": {
+     "views": [
+      {
+       "cell_index": 1
+      }
+     ]
+    },
+    "a38729a894d94cde9582342f91a0f3fc": {
+     "views": [
+      {
+       "cell_index": 1
+      }
+     ]
+    },
+    "c83c0e42bfab4fd683f5e2530a8bc3b1": {
      "views": [
       {
        "cell_index": 1


### PR DESCRIPTION
To enable compatibility with the upcoming Dicom viewer plugin for girder. Each dicom slice within a folder is uploaded to a single item with a name matching the folder.
